### PR TITLE
The cf client only accepts 'memory:' in manifest.yml

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,4 +1,4 @@
 applications:
 - name: DoggyAdoption
   description : Simple demo app that has fun dog pictures.
-  mem: 256M
+  memory: 256M


### PR DESCRIPTION
The shorter form is ignored - not sure when this changed.